### PR TITLE
Fix crash caused by wires connected each other

### DIFF
--- a/qschematic/wire_system/wire.cpp
+++ b/qschematic/wire_system/wire.cpp
@@ -580,7 +580,7 @@ void wire::simplify()
 
 bool wire::connect_wire(wire* wire)
 {
-    if (m_connectedWires.contains(wire)) {
+    if (m_connectedWires.contains(wire) || wire->connected_wires().contains(this)) {
         return false;
     }
     m_connectedWires.append(wire);


### PR DESCRIPTION
Fix crash if Connector moves with two wires connected when wires are connected each other.